### PR TITLE
Unpin vulnerable server-runtime resolutions and force deepmerge-ts 8

### DIFF
--- a/server-runtime/package.json
+++ b/server-runtime/package.json
@@ -36,10 +36,11 @@
   "resolutions": {
     "axios/form-data": "4.0.6",
     "defu": "6.1.7",
+    "deepmerge-ts": "8.0.0",
     "effect": "3.21.0",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "path-to-regexp": "8.4.2",
-    "postcss": "8.5.19",
+    "postcss": "8.5.23",
     "qs": "6.15.3",
     "ws": "8.21.1"
   }

--- a/server-runtime/yarn.lock
+++ b/server-runtime/yarn.lock
@@ -954,10 +954,10 @@ debug@~4.3.1:
   dependencies:
     ms "^2.1.3"
 
-deepmerge-ts@7.1.5:
-  version "7.1.5"
-  resolved "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz#ff818564007f5c150808d2b7b732cac83aa415ab"
-  integrity sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==
+deepmerge-ts@7.1.5, deepmerge-ts@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.0.tgz#9fde9f1122d44ab4d1de31eda3e20b55693c8e59"
+  integrity sha512-ICNjaP0ML+eSdEpJYQC46XiAn/UjAdwbEl0dE8p85ZTeNDinN4Kd4+9jS4OSAuH7st6eC7rQhsqTF5zIDaUm2g==
 
 deepmerge@^4.2.2:
   version "4.3.1"
@@ -1504,10 +1504,10 @@ joi@^18.2.3:
     "@hapi/topo" "^6.0.2"
     "@standard-schema/spec" "^1.1.0"
 
-js-yaml@4.3.0, js-yaml@^4.1.0, js-yaml@^4.2.0:
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@4.3.1, js-yaml@^4.1.0, js-yaml@^4.2.0:
+  version "4.3.1"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 
@@ -1789,9 +1789,9 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.12:
+nanoid@^3.3.16:
   version "3.3.18"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
   integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 negotiator@0.6.3:
@@ -2059,12 +2059,12 @@ pkg-types@^2.2.0:
     exsolve "^1.0.8"
     pathe "^2.0.3"
 
-postcss@8.5.19, postcss@^8.3.11:
-  version "8.5.19"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz#45ad5cfde499408e20147348237551381a922037"
-  integrity sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==
+postcss@8.5.23, postcss@^8.3.11:
+  version "8.5.23"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz#3493550116f478487298301d2c2e8dc5a56e6594"
+  integrity sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==
   dependencies:
-    nanoid "^3.3.12"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
## Why

Dependabot security updates for the /server-runtime manifest keep failing: its resolutions still pin js-yaml 4.3.0 and postcss 8.5.19 (below the fixed versions), and the prisma config chain pins deepmerge-ts 7.1.5 (non-vulnerable line starts at 8.0.0).

## What Changed

Bumped js-yaml to 4.3.1 and postcss to 8.5.23, added a deepmerge-ts 8.0.0 resolution, regenerated the lockfile, and preserved the redis-adapter dependency metadata.

## Verification

- CI (install, typecheck, build) runs on this branch.